### PR TITLE
Version 1.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 project(thinkpad_keyboard_backlight)
 set(PROJECT_VERSION_MAJOR  1)
-set(PROJECT_VERSION_MINOR  2)
-set(PROJECT_VERSION_PATCH  1)
+set(PROJECT_VERSION_MINOR  3)
+set(PROJECT_VERSION_PATCH  0)
 
 # Add version compile definition
 add_compile_definitions(VERSION="${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(PROJECT_VERSION_PATCH  0)
 # Add version compile definition
 add_compile_definitions(VERSION="${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 
+
 set(CMAKE_INSTALL_PREFIX /usr/bin)
 set(CMAKE_CXX_STANDARD 17)
 
@@ -28,6 +29,8 @@ set(OPTIMIZATION_LEVEL "-O3")
 # ""    None
 set(DEBUG_LEVEL "")
 
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG=1")
+
 # Configure C++ compiler flags
 set(CMAKE_CXX_FLAGS "${OPTIMIZATION_LEVEL} \
     ${DEBUG_LEVEL} \
@@ -40,10 +43,16 @@ set(APP_TARGET_PATH ${CMAKE_INSTALL_PREFIX}/keyboard_backlight)
 set(APP_NAME keyboard_backlight)
 
 find_package (Threads)
+# Some versions of gcc need to link filesystem lib
+if (CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+    set(CXX_FILESYSTEM_LIBRARIES stdc++fs)
+else()
+    set(CXX_FILESYSTEM_LIBRARIES)
+endif()
 
 
 add_executable(${APP_NAME} kbd_backlight.cpp)
-target_link_libraries (keyboard_backlight ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries (keyboard_backlight ${CMAKE_THREAD_LIBS_INIT} ${CXX_FILESYSTEM_LIBRARIES})
 
 install(TARGETS keyboard_backlight DESTINATION ${CMAKE_INSTALL_PREFIX})
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,6 +9,7 @@ url='https://github.com/alexmohr/keyboard-backlight'
 license=('MIT')
 depends=('libinput')
 makedepends=('git' 'cmake' 'gcc')
+backup=('etc/systemd/system/keyboard_backlight.service')
 
 source=("git+https://github.com/alexmohr/keyboard-backlight")
 sha512sums=('SKIP')

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ sudo rm /usr/bin/keyboard_backlight
 
 ## Configuration
 ````
-./keyboard_backlight 1.3.0 
+keyboard_backlight 1.3.0 
     -h show this help
     -i ignore an input device
        This device does not re enable keyboard backlight.
@@ -73,5 +73,4 @@ sudo rm /usr/bin/keyboard_backlight
     -f stay in foreground and do not start daemon
     -s Set a brightness value and exit
 ````
-
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ keyboard_backlight 1.2.1
     -b set keyboard backlight device path
        defaults to /sys/class/leds/tpacpi::kbd_backlight
     -f stay in foreground and do not start daemon
-    -s Set a brightness value from 0..2 and exit
+    -s Set a brightness value and exit
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ other devices as well
 ### Arch Linux
 The package is in the AUR and called  ``tp-kb-backlight-git``
 
-### Install from source
-To build the binary run
+### Build from source
+Requirements to build the software from source are:
+* Compiler with C++17 suppport
+* CMake
+
+To build the binary run:
 ````
 mkdir build
 cd build

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ sudo rm /usr/bin/keyboard_backlight
 
 ## Configuration
 ````
-keyboard_backlight 1.2.1 
+./keyboard_backlight 1.3.0 
     -h show this help
     -i ignore an input device
        This device does not re enable keyboard backlight.
@@ -69,7 +69,7 @@ keyboard_backlight 1.2.1
        1 use all internal mice only
        2 ignore mice
     -b set keyboard backlight device path
-       defaults to /sys/class/leds/tpacpi::kbd_backlight
+       defaults to /sys/class/leds/tpacpi::kbd_backlight/brightness
     -f stay in foreground and do not start daemon
     -s Set a brightness value and exit
 ````

--- a/kbd_backlight.cpp
+++ b/kbd_backlight.cpp
@@ -184,12 +184,11 @@ void brightness_control(const std::string &brightnessPath,
 	  printf("o: %lu c: %lu\n", originalBrightness_, currentBrightness_);
 #endif
 
+	  file_read_uint64(brightnessPath, &currentBrightness_);
 	  if (currentBrightness_ != 0) {
-		file_read_uint64(brightnessPath, &originalBrightness_);
-		currentBrightness_ = 0;
-
+		originalBrightness_ = currentBrightness_;
+	    currentBrightness_ = 0;
 		file_write_uint64(brightnessPath, 0);
-
 #if DEBUG
 		printf("o: %lu c: %lu\n", originalBrightness_, currentBrightness_);
 		printf("turning off \n");

--- a/kbd_backlight.cpp
+++ b/kbd_backlight.cpp
@@ -72,7 +72,7 @@ void help(const char* name) {
 		 "    -b set keyboard backlight device path\n"
 		 "       defaults to /sys/class/leds/tpacpi::kbd_backlight\n"
 		 "    -f stay in foreground and do not start daemon\n"
-		 "    -s Set a brightness value from 0..2 and exit\n"
+		 "    -s Set a brightness value and exit\n"
 
   );
 }
@@ -286,10 +286,6 @@ void parse_opts(int argc,
 		break;
 	  case 's':
 		setBrightness = strtol(optarg, nullptr, 0);
-		if (setBrightness > 2 || setBrightness < 0) {
-		  printf("%s is not a valid brightness\n", optarg);
-		  exit(EXIT_FAILURE);
-		}
 		break;
 	  case 'h':
 	  default:

--- a/kbd_backlight.cpp
+++ b/kbd_backlight.cpp
@@ -252,9 +252,6 @@ void brightness_control(const std::string &brightnessPath,
 	if (passedMs.count() >= static_cast<long>(timeoutMs)) {
 
 	  print_debug_n("Timeout reached \n");
-	  print_debug("Original brightness: %lu Current Brightness: %lu\n",
-				  originalBrightness_,
-				  currentBrightness_);
 
 	  file_read_uint64(brightnessPath, &tmpBrightness);
 	  if (tmpBrightness != 0) {

--- a/kbd_backlight.cpp
+++ b/kbd_backlight.cpp
@@ -236,7 +236,7 @@ void brightness_control(const std::string &brightnessPath,
 	if (lastEvent_ < std::chrono::system_clock::now()) {
 	  auto sleepTime = std::chrono::milliseconds(timeoutMs - passedMs.count());
 	  if (0 != sleepTime.count()) {
-	    print_debug("Sleeping for %lu ms\n", sleepTime.count());
+		print_debug("Sleeping for %lu ms\n", sleepTime.count());
 		std::this_thread::sleep_for(sleepTime);
 	  }
 	}
@@ -300,8 +300,10 @@ void signal_handler(int sig) {
 bool is_brightness_writable(const std::string &brightnessPath) {
   if (!file_read_uint64(brightnessPath, &originalBrightness_)
 	  || !file_write_uint64(brightnessPath, originalBrightness_)) {
-	std::cout << "Write access to brightness device descriptor failed.\n"
-				 "Please run with root privileges" << std::endl;
+	std::cout << "Write access to brightness device "
+			  << brightnessPath
+			  << " failed. Please run with root privileges"
+			  << std::endl;
 	return false;
   }
   return true;

--- a/kbd_backlight.cpp
+++ b/kbd_backlight.cpp
@@ -231,6 +231,7 @@ std::vector<int> open_devices(const std::vector<std::string> &input_devices) {
 
 void brightness_control(const std::string &brightnessPath,
 						unsigned long timeoutMs) {
+  unsigned long tmpBrightness = currentBrightness_;
   while (!end_) {
 	auto passedMs = std::chrono::duration_cast<
 		std::chrono::milliseconds>(
@@ -255,9 +256,9 @@ void brightness_control(const std::string &brightnessPath,
 				  originalBrightness_,
 				  currentBrightness_);
 
-	  file_read_uint64(brightnessPath, &currentBrightness_);
-	  if (currentBrightness_ != 0) {
-		originalBrightness_ = currentBrightness_;
+	  file_read_uint64(brightnessPath, &tmpBrightness);
+	  if (tmpBrightness != 0) {
+		originalBrightness_ = tmpBrightness;
 		currentBrightness_ = 0;
 		file_write_uint64(brightnessPath, 0);
 		print_debug("New Original brightness: %lu New Current Brightness: %lu\n",


### PR DESCRIPTION
## Features: 
* Brightness now can be arbitrary int 
* Name of brightness file can now be passed instead of path.
* Debug log can be enabled via Cmake option

## Bugfixes: 
* Preventing overwrite of service file in pacman
* Fixed lighting when backlight is off when program is started
* Reading keyboard from proc fs, which fixes not detected keyboard for some devices
* Compiler support for gcc8
* If user does not move the mouse or press a key after turning backlight off it's not turned on again anymore

Fixes all issues mentioned in #9 