### PR TITLE
Add key ignoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,9 @@ keyboard_backlight 1.3.0
        defaults to /sys/class/leds/tpacpi::kbd_backlight/brightness
     -f stay in foreground and do not start daemon
     -s Set a brightness value and exit
+    -k (key code) Ignore key code
+       You can get the values using -d option.
+       Separate multiple values by comma, e.g. '10,20,30'.
+    -d Show pressed key codes
 ````
 

--- a/kbd_backlight.cpp
+++ b/kbd_backlight.cpp
@@ -274,26 +274,20 @@ void brightness_control(const std::string &brightnessPath,
 }
 
 void read_events(int devFd, const std::string &brightnessPath,
-				 const std::map<int, bool> &ignoredKeys, bool showPressedKeys)
-{
+				 const std::map<int, bool> &ignoredKeys, bool showPressedKeys) {
 	int ignoreNextValues = 0;
-	while (!end_)
-	{
+	while (!end_) {
 		struct input_event ie = {};
 		int rd = read(devFd, &ie, sizeof(struct input_event));
-		if (rd != 0)
-		{
-			if (showPressedKeys && ie.type == EV_MSC && ie.code == MSC_SCAN)
-			{
+		if (rd != 0) {
+			if (showPressedKeys && ie.type == EV_MSC && ie.code == MSC_SCAN) {
 				printf("Pressed key value: %d\n", ie.value);
 				fflush(stdout);
 			}
 
 			bool correctKey = true;
-			if (ie.type == EV_MSC && ie.code == MSC_SCAN)
-			{
-				if (ignoredKeys.find(ie.value)->second == true)
-				{
+			if (ie.type == EV_MSC && ie.code == MSC_SCAN) {
+				if (ignoredKeys.find(ie.value)->second == true) {
 					correctKey = false;
 					// There are 3 events for every key press, so we are ignoring
 					// the next 2 events
@@ -304,15 +298,12 @@ void read_events(int devFd, const std::string &brightnessPath,
 					fflush(stdout);
 #endif
 				}
-			}
-			else if (ignoreNextValues > 0)
-			{
+			} else if (ignoreNextValues > 0) {
 				correctKey = false;
 				ignoreNextValues--;
 			}
 
-			if (correctKey)
-			{
+			if (correctKey) {
 #if DEBUG_KEYS_IGNORE
 				printf("Processing key type: %u, code: %u, value: %d\n",
 					   ie.type, ie.code, ie.value);
@@ -320,8 +311,7 @@ void read_events(int devFd, const std::string &brightnessPath,
 #endif
 				lastEvent_ = std::chrono::system_clock::now();
 
-				if (currentBrightness_ != originalBrightness_)
-				{
+				if (currentBrightness_ != originalBrightness_) {
 					file_write_uint64(brightnessPath, originalBrightness_);
 					currentBrightness_ = originalBrightness_;
 

--- a/kbd_backlight.cpp
+++ b/kbd_backlight.cpp
@@ -436,7 +436,7 @@ int main(int argc, char **argv) {
   std::vector<std::string> inputDevices;
   std::vector<std::string> ignoredDevices;
   std::map<int, bool> ignoredKeys;
-	bool showPressedKeys = false;
+  bool showPressedKeys = false;
 
   signal(SIGTERM, signal_handler);
   signal(SIGKILL, signal_handler);

--- a/kbd_backlight.cpp
+++ b/kbd_backlight.cpp
@@ -274,7 +274,7 @@ void brightness_control(const std::string &brightnessPath,
 }
 
 void read_events(int devFd, const std::string &brightnessPath,
-				 const std::vector<int> &ignoredKeys, bool showPressedKeys)
+				 const std::map<int, bool> &ignoredKeys, bool showPressedKeys)
 {
 	int ignoreNextValues = 0;
 	while (!end_)
@@ -292,9 +292,7 @@ void read_events(int devFd, const std::string &brightnessPath,
 			bool correctKey = true;
 			if (ie.type == EV_MSC && ie.code == MSC_SCAN)
 			{
-				if (std::find(std::begin(ignoredKeys),
-							  std::end(ignoredKeys),
-							  ie.value) != std::end(ignoredKeys))
+				if (ignoredKeys.find(ie.value)->second == true)
 				{
 					correctKey = false;
 					// There are 3 events for every key press, so we are ignoring
@@ -370,7 +368,7 @@ void parse_opts(int argc,
 				std::string &backlightPath,
 				bool &foreground,
 				long &setBrightness,
-				std::vector<int> &ignoredKeys,
+				std::map<int, bool> &ignoredKeys,
 				bool &showPressedKeys) {
   int c;
   std::istringstream ss;
@@ -428,7 +426,7 @@ void parse_opts(int argc,
 	  case 'k':
 		ss = std::istringstream(optarg);
 		while (std::getline(ss, token, ',')) {
-		  ignoredKeys.push_back(std::stoi(token));
+		  ignoredKeys[std::stoi(token)] = true;
 		}
 		break;
 	  case 'd':
@@ -447,7 +445,7 @@ int main(int argc, char **argv) {
 
   std::vector<std::string> inputDevices;
   std::vector<std::string> ignoredDevices;
-  std::vector<int> ignoredKeys;
+  std::map<int, bool> ignoredKeys;
 	bool showPressedKeys = false;
 
   signal(SIGTERM, signal_handler);

--- a/kbd_backlight.cpp
+++ b/kbd_backlight.cpp
@@ -283,14 +283,14 @@ void read_events(int devFd, const std::string &brightnessPath,
 		int rd = read(devFd, &ie, sizeof(struct input_event));
 		if (rd != 0)
 		{
-			if (showPressedKeys && ie.type == 4 && ie.code == 4)
+			if (showPressedKeys && ie.type == EV_MSC && ie.code == MSC_SCAN)
 			{
 				printf("Pressed key value: %d\n", ie.value);
 				fflush(stdout);
 			}
 
 			bool correctKey = true;
-			if (ie.type == 4 && ie.code == 4)
+			if (ie.type == EV_MSC && ie.code == MSC_SCAN)
 			{
 				if (std::find(std::begin(ignoredKeys),
 							  std::end(ignoredKeys),

--- a/kbd_backlight.cpp
+++ b/kbd_backlight.cpp
@@ -297,6 +297,8 @@ void read_events(int devFd, const std::string &brightnessPath,
 							  ie.value) != std::end(ignoredKeys))
 				{
 					correctKey = false;
+					// There are 3 events for every key press, so we are ignoring
+					// the next 2 events
 					ignoreNextValues = 2;
 #if DEBUG_KEYS_IGNORE
 					printf("Ignoring key: type: %u, code: %u, value: %d\n",


### PR DESCRIPTION
Added `-k` option to ignore certain key codes.
For example, when you don't want to turn on backlight when pressing arrow keys.
Also, `-d` option shows key values, to be fed to `-k`.